### PR TITLE
Fixup building on Ubuntu 18.04

### DIFF
--- a/src/tables/heightmaptablemodel.cpp
+++ b/src/tables/heightmaptablemodel.cpp
@@ -2,6 +2,7 @@
 // Copyright 2015 Hayrullin Denis Ravilevich
 
 #include "heightmaptablemodel.h"
+#include <cmath>
 
 HeightMapTableModel::HeightMapTableModel(QObject *parent) : QAbstractTableModel(parent)
 {

--- a/src/utils/util.h
+++ b/src/utils/util.h
@@ -8,6 +8,7 @@
 #include <QVector3D>
 #include <QEventLoop>
 #include <QTimer>
+#include <cmath>
 
 class Util
 {


### PR DESCRIPTION
Build errors examples:

```
../src/utils/util.h:17:19: error: ‘isnan’ is not a member of ‘std’
         if (!std::isnan(v1) && !std::isnan(v2)) return qMin<double>(v1, v2);
                   ^~~~~
```

```
../src/tables/heightmaptablemodel.cpp:20:24: error: ‘NAN’ was not declared in this scope
             row.append(NAN);
                        ^~~
```